### PR TITLE
Update class-wp-rest-site-health-controller.php

### DIFF
--- a/endpoints/class-wp-rest-site-health-controller.php
+++ b/endpoints/class-wp-rest-site-health-controller.php
@@ -66,6 +66,10 @@ class WP_ZABBIX_SiteHealth_Controller extends WP_REST_Controller {
      */
 	public function get_items( $request ) {
 		$response = [];
+		
+	if(!function_exists('got_url_rewrite')) {
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+	}
 
         if ( !class_exists( 'WP_Debug_Data' ) ) {
             require_once ABSPATH . 'wp-admin/includes/class-wp-debug-data.php';


### PR DESCRIPTION
FIX error "Call to undefined function got_url_rewrite()" on WP 7.5 and PHP 7.4